### PR TITLE
Try to build site with jupyter-lite

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -30,6 +30,18 @@ jobs:
       - name: Build docs
         run: jupyter-book build -W --keep-going .
 
+      - name: Install jupyterlite dependencies
+        run: python3 -m pip install ".[lite]"
+
+      - name: Build site for jupyterlite
+        run: |
+          mkdir content
+          find examples -name '*.py' -exec jupytext --to ipynb {} +
+          find examples -name '*.ipynb' -exec mv {} content ';'
+          cp -r src/zero_mech content/
+          jupyter lite build --contents content --output-dir ./_build/html/lite
+
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,17 @@ test = [
     "pytest-cov",
 
 ]
+lite = [
+    "jupyterlite-core==0.5.0",
+    "jupyterlab~=4.3.4",
+    "notebook~=7.3.2",
+    "jupyterlite-pyodide-kernel==0.5.0",
+    "jupyterlab-night",
+    "jupyterlab_miami_nights",
+    "ipywidgets>=8.1.3,<9",
+    "ipyevents>=2.0.1",
+    "ipympl>=0.8.2",
+]
 
 [project.scripts]
 gotranx = "gotranx.cli:app"


### PR DESCRIPTION
Attempt to build site with [jupyerlite](https://jupyterlite.readthedocs.io/en/stable/index.html) so that users can go to https://computationalphysiology.github.io/zero-mech/lite to run the notebooks with jupyter-lite